### PR TITLE
Fix nested generic type resolution on duplicated interfaces

### DIFF
--- a/src/main/java/ru/vyarus/java/generics/resolver/context/container/GenericArrayTypeImpl.java
+++ b/src/main/java/ru/vyarus/java/generics/resolver/context/container/GenericArrayTypeImpl.java
@@ -26,6 +26,26 @@ public class GenericArrayTypeImpl implements GenericArrayType {
     }
 
     @Override
+    @SuppressWarnings({"checkstyle:needbraces", "PMD.IfStmtsMustUseBraces", "PMD.OnlyOneReturn"})
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GenericArrayTypeImpl)) return false;
+
+        final GenericArrayTypeImpl that = (GenericArrayTypeImpl) o;
+
+        if (componentType != null
+                ? !componentType.equals(that.componentType)
+                : that.componentType != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return componentType != null ? componentType.hashCode() : 0;
+    }
+
+    @Override
     public String toString() {
         return TypeToStringUtils.toStringType(this, Collections.<String, Type>emptyMap());
     }

--- a/src/main/java/ru/vyarus/java/generics/resolver/context/container/ParameterizedTypeImpl.java
+++ b/src/main/java/ru/vyarus/java/generics/resolver/context/container/ParameterizedTypeImpl.java
@@ -41,6 +41,29 @@ public class ParameterizedTypeImpl implements ParameterizedType {
     }
 
     @Override
+    @SuppressWarnings({"checkstyle:needbraces", "PMD.IfStmtsMustUseBraces", "PMD.OnlyOneReturn"})
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ParameterizedTypeImpl)) return false;
+
+        final ParameterizedTypeImpl that = (ParameterizedTypeImpl) o;
+
+        if (!Arrays.equals(actualArguments, that.actualArguments)) return false;
+        if (ownerType != null ? !ownerType.equals(that.ownerType) : that.ownerType != null) return false;
+        if (rawType != null ? !rawType.equals(that.rawType) : that.rawType != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = rawType != null ? rawType.hashCode() : 0;
+        result = 31 * result + (actualArguments != null ? Arrays.hashCode(actualArguments) : 0);
+        result = 31 * result + (ownerType != null ? ownerType.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return TypeToStringUtils.toStringType(this, Collections.<String, Type>emptyMap());
     }

--- a/src/main/java/ru/vyarus/java/generics/resolver/context/container/WildcardTypeImpl.java
+++ b/src/main/java/ru/vyarus/java/generics/resolver/context/container/WildcardTypeImpl.java
@@ -35,6 +35,27 @@ public class WildcardTypeImpl implements WildcardType {
     }
 
     @Override
+    @SuppressWarnings({"checkstyle:needbraces", "PMD.IfStmtsMustUseBraces", "PMD.OnlyOneReturn"})
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof WildcardTypeImpl)) return false;
+
+        final WildcardTypeImpl that = (WildcardTypeImpl) o;
+
+        if (!Arrays.equals(lowerBounds, that.lowerBounds)) return false;
+        if (!Arrays.equals(upperBounds, that.upperBounds)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = upperBounds != null ? Arrays.hashCode(upperBounds) : 0;
+        result = 31 * result + (lowerBounds != null ? Arrays.hashCode(lowerBounds) : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return TypeToStringUtils.toStringType(this, Collections.<String, Type>emptyMap());
     }

--- a/src/test/groovy/ru/vyarus/java/generics/resolver/NestedTypesTest.groovy
+++ b/src/test/groovy/ru/vyarus/java/generics/resolver/NestedTypesTest.groovy
@@ -1,0 +1,32 @@
+package ru.vyarus.java.generics.resolver
+
+import ru.vyarus.java.generics.resolver.context.GenericsContext
+import ru.vyarus.java.generics.resolver.support.nestedtype.RootClass
+import ru.vyarus.java.generics.resolver.support.nestedtype.SubClass2
+import ru.vyarus.java.generics.resolver.support.nestedtype.NestedGenericType
+import spock.lang.Specification
+
+/**
+ * Generic type resolution should succeed, if a class implement the same interface
+ * through multiple ways, if the resolved generic types are the same.
+ *
+ * SubClass2
+ *   -&gt; SubClass1&lt;T&gt;         (T = GenericType)
+ *     -&gt; RootClass&lt;T&gt;       (T = NestedGenericType&lt;GenericType&gt;)
+ *       -&gt; RootInterface&lt;T&gt; (T = NestedGenericType&lt;GenericType&gt;)
+ * SubClass2
+ *   -&gt; SubClass1&lt;T&gt;         (T = GenericType)
+ *     -&gt; SubInterface&lt;T&gt;    (T = NestedGenericType&lt;GenericType&gt;)
+ *       -&gt; RootInterface&lt;T&gt; (T = NestedGenericType&lt;GenericType&gt;)
+ *
+ * @author Adam Biczok
+ * @since 04.03.2015
+ */
+class NestedTypesTest extends Specification {
+    def "Check generic resolution on duplicated interfaces if generic types are the same"() {
+        when: "resolving generic type"
+        GenericsContext context = GenericsResolver.resolve(SubClass2).type(RootClass)
+        then: "correct generic values resolved"
+        context.generic("T") == NestedGenericType
+    }
+}

--- a/src/test/groovy/ru/vyarus/java/generics/resolver/support/nestedtype/GenericType.groovy
+++ b/src/test/groovy/ru/vyarus/java/generics/resolver/support/nestedtype/GenericType.groovy
@@ -1,0 +1,8 @@
+package ru.vyarus.java.generics.resolver.support.nestedtype;
+
+/**
+ * @author Adam Biczok
+ * @since 04.03.2015
+ */
+public class GenericType {
+}

--- a/src/test/groovy/ru/vyarus/java/generics/resolver/support/nestedtype/NestedGenericType.groovy
+++ b/src/test/groovy/ru/vyarus/java/generics/resolver/support/nestedtype/NestedGenericType.groovy
@@ -1,0 +1,8 @@
+package ru.vyarus.java.generics.resolver.support.nestedtype
+
+/**
+ * @author Adam Biczok
+ * @since 04.03.2015
+ */
+interface NestedGenericType<T> {
+}

--- a/src/test/groovy/ru/vyarus/java/generics/resolver/support/nestedtype/RootClass.groovy
+++ b/src/test/groovy/ru/vyarus/java/generics/resolver/support/nestedtype/RootClass.groovy
@@ -1,0 +1,8 @@
+package ru.vyarus.java.generics.resolver.support.nestedtype;
+
+/**
+ * @author Adam Biczok
+ * @since 04.03.2015
+ */
+public abstract class RootClass<T> implements RootInterface<T> {
+}

--- a/src/test/groovy/ru/vyarus/java/generics/resolver/support/nestedtype/RootInterface.groovy
+++ b/src/test/groovy/ru/vyarus/java/generics/resolver/support/nestedtype/RootInterface.groovy
@@ -1,0 +1,8 @@
+package ru.vyarus.java.generics.resolver.support.nestedtype;
+
+/**
+ * @author Adam Biczok
+ * @since 04.03.2015
+ */
+public interface RootInterface<T> {
+}

--- a/src/test/groovy/ru/vyarus/java/generics/resolver/support/nestedtype/SubClass1.groovy
+++ b/src/test/groovy/ru/vyarus/java/generics/resolver/support/nestedtype/SubClass1.groovy
@@ -1,0 +1,11 @@
+package ru.vyarus.java.generics.resolver.support.nestedtype;
+
+/**
+ * @author Adam Biczok
+ * @since 04.03.2015
+ */
+public class SubClass1<T>
+        extends RootClass<NestedGenericType<T>>
+        implements SubInterface<NestedGenericType<T>> {
+}
+

--- a/src/test/groovy/ru/vyarus/java/generics/resolver/support/nestedtype/SubClass2.groovy
+++ b/src/test/groovy/ru/vyarus/java/generics/resolver/support/nestedtype/SubClass2.groovy
@@ -1,0 +1,8 @@
+package ru.vyarus.java.generics.resolver.support.nestedtype;
+
+/**
+ * @author Adam Biczok
+ * @since 04.03.2015
+ */
+class SubClass2 extends SubClass1<GenericType> {
+}

--- a/src/test/groovy/ru/vyarus/java/generics/resolver/support/nestedtype/SubInterface.groovy
+++ b/src/test/groovy/ru/vyarus/java/generics/resolver/support/nestedtype/SubInterface.groovy
@@ -1,0 +1,8 @@
+package ru.vyarus.java.generics.resolver.support.nestedtype;
+
+/**
+ * @author Adam Biczok
+ * @since 04.03.2015
+ */
+public interface SubInterface<T> extends RootInterface<T> {
+}


### PR DESCRIPTION
I fixed the nested generic type resolution on duplicated interfaces. It throws an IllegalStateException (Duplicate interface declaration in hierarchy) even if the generic nested types are the same.